### PR TITLE
Add jsonb type definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.7
+  - 1.11
 
 go_import_path: github.com/lib/pq
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
-	"strings"
+	"regexp"
 	"testing"
 	"time"
 
@@ -278,24 +278,26 @@ func TestInfinityTimestamp(t *testing.T) {
 	var err error
 	var resultT time.Time
 
-	expectedErrorStrPrefix := `sql: Scan error on column index 0: unsupported`
+	expectedErrorStrRegexp := regexp.MustCompile(
+		`^sql: Scan error on column index 0(, name "timestamp(tz)?"|): unsupported`)
 	type testCases []struct {
-		Query                string
-		Param                string
-		ExpectedErrStrPrefix string
-		ExpectedVal          interface{}
+		Query                  string
+		Param                  string
+		ExpectedErrorStrRegexp *regexp.Regexp
+		ExpectedVal            interface{}
 	}
 	tc := testCases{
-		{"SELECT $1::timestamp", "-infinity", expectedErrorStrPrefix, "-infinity"},
-		{"SELECT $1::timestamptz", "-infinity", expectedErrorStrPrefix, "-infinity"},
-		{"SELECT $1::timestamp", "infinity", expectedErrorStrPrefix, "infinity"},
-		{"SELECT $1::timestamptz", "infinity", expectedErrorStrPrefix, "infinity"},
+		{"SELECT $1::timestamp", "-infinity", expectedErrorStrRegexp, "-infinity"},
+		{"SELECT $1::timestamptz", "-infinity", expectedErrorStrRegexp, "-infinity"},
+		{"SELECT $1::timestamp", "infinity", expectedErrorStrRegexp, "infinity"},
+		{"SELECT $1::timestamptz", "infinity", expectedErrorStrRegexp, "infinity"},
 	}
 	// try to assert []byte to time.Time
 	for _, q := range tc {
 		err = db.QueryRow(q.Query, q.Param).Scan(&resultT)
-		if !strings.HasPrefix(err.Error(), q.ExpectedErrStrPrefix) {
-			t.Errorf("Scanning -/+infinity, expected error to have prefix %q, got %q", q.ExpectedErrStrPrefix, err)
+		if !q.ExpectedErrorStrRegexp.MatchString(err.Error()) {
+			t.Errorf("Scanning -/+infinity, expected error to match regexp %q, got %q",
+				q.ExpectedErrorStrRegexp, err)
 		}
 	}
 	// yield []byte

--- a/oid/types.go
+++ b/oid/types.go
@@ -144,6 +144,7 @@ const (
 	T__regconfig       Oid = 3735
 	T_regdictionary    Oid = 3769
 	T__regdictionary   Oid = 3770
+	T_jsonb            Oid = 3802
 	T_anyrange         Oid = 3831
 	T_event_trigger    Oid = 3838
 	T_int4range        Oid = 3904


### PR DESCRIPTION
This PR adds a Jsonb type definition to the library. It is used it [this PR](https://github.com/remerge/p2q/pull/28).

It also updates the tested version of Go to 1.11. Go 1.7 can't be used anymore because `goimports` tool uses `sort.Slice` method introduced in Go 1.8. `encoder_test.go` updated with the changes from the upstream to pass under Go 1.11.